### PR TITLE
✨ feat: refresh토큰,access토큰 기능 구현

### DIFF
--- a/now-waypoint-core/build.gradle
+++ b/now-waypoint-core/build.gradle
@@ -27,6 +27,8 @@ def profile = project.hasProperty('profile') ? project.profile : 'dev'
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'it.ozimov:embedded-redis:0.7.2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/exception/TokenNotFoundException.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/exception/TokenNotFoundException.java
@@ -1,0 +1,7 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception;
+
+public class TokenNotFoundException extends RuntimeException{
+    public TokenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/jwt/JwtFilter.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/jwt/JwtFilter.java
@@ -1,7 +1,10 @@
 package isn_t_this_e_not_i.now_waypoint_core.domain.auth.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.dto.UserDetail;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.TokenService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.UserDetailService;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,10 +13,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -21,32 +29,80 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserDetailService userDetailService;
+    private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String authorization = request.getHeader("Authorization");
-        log.info("authorization = {}", authorization);
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            log.info("유효한 토큰이 없습니다.");
             filterChain.doFilter(request,response);
             return;
         }
 
         String token = authorization.split(" ")[1];
+        String accessToken = null;
 
+        //accessToken 만료시 refreshToken이 유효하다면 accessToken재발급
         if (jwtUtil.isExpired(token)) {
-            log.info("토큰이 만료되었습니다.");
-            filterChain.doFilter(request,response);
-            return;
+            log.info("AccessToken이 만료되었습니다.");
+            Optional<Token> getToken = tokenService.findByAccessToken(token);
+
+            if (getToken.isPresent()) {
+                String refreshToken = getToken.get().getRefreshToken();
+
+                //refreshToken이 만료 검증
+                if (jwtUtil.isExpired(refreshToken)) {
+                    log.info("refreshToken이 만료되었습니다");
+                    filterChain.doFilter(request,response);
+                    return;
+                }
+
+                String loginId = getToken.get().getLoginId();
+                UserDetail userDetail = (UserDetail) userDetailService.loadUserByUsername(loginId);
+                accessToken = jwtUtil.getAccessToken(userDetail);
+                log.info("AccessToken이 재발급되었습니다.");
+                response.setHeader("Authorization", "Bearer " + accessToken);
+                responseToClient(response,accessToken);
+
+                //재발급된 토큰을 SecurityContextHolder에 저장
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetail, null, userDetail.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                //재발급된 토큰으로 accessToken값 변경
+                tokenService.updateAccessToken(token, accessToken);
+                response.setHeader("Authorization", "Bearer " + accessToken);
+                return;
+            }else{
+                log.info("일치하는 accessToken이 없습니다.");
+                filterChain.doFilter(request,response);
+                return;
+            }
+        }
+        //accessToken이 만료가 안된상태
+        else{
+            log.info("accessToken이 유효합니다.");
+            String loginId = jwtUtil.getLoginId(token);
+            UserDetail userDetail = (UserDetail) userDetailService.loadUserByUsername(loginId);
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetail, null, userDetail.getAuthorities());
+            authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+            accessToken = token;
         }
 
-        log.info("인증된 사용자입니다.");
-        String loginId = jwtUtil.getLoginId(token);
-        UserDetail userDetails = (UserDetail) userDetailService.loadUserByUsername(loginId);
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-        response.setHeader("Authorization", "Bearer " + token);
+        response.setHeader("Authorization", "Bearer " + accessToken);
         filterChain.doFilter(request,response);
+    }
+
+    private void responseToClient(HttpServletResponse response,String accessToken) throws IOException {
+        Map<String, String> userInfo = new HashMap<>();
+        userInfo.put("access_token", accessToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        PrintWriter writer = response.getWriter();
+        writer.print(objectMapper.writeValueAsString(userInfo));
+        writer.flush();
     }
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/jwt/JwtLogoutService.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/jwt/JwtLogoutService.java
@@ -1,24 +1,53 @@
 package isn_t_this_e_not_i.now_waypoint_core.domain.auth.jwt;
 
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception.TokenNotFoundException;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.TokenService;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class JwtLogoutService implements LogoutHandler {
+
+    private final TokenService tokenService;
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         String authorization = request.getHeader("Authorization");
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.info("인증되지 않은 사용자입니다.");
             return;
         }
 
+        String token = authorization.split(" ")[1];
+
+        //로그아웃시 token정보 제거
+        if (!StringUtils.isEmpty(token) && !"undefined".equals(token)) {
+            Optional<Token> getToken = tokenService.findByAccessToken(token);
+            if (getToken.isPresent()) {
+                String accessToken = getToken.get().getAccessToken();
+                tokenService.deleteToken(accessToken);
+                log.info("회원이 로그아웃하였습니다. 토큰삭제");
+            }else{
+                throw new TokenNotFoundException("일치하는 토큰이 없습니다.");
+            }
+        }
+
+        //header에서 토큰 제거
         response.setHeader("Authorization", "");
+        //SecurityContextHoler에서 토큰 제거
+        SecurityContextHolder.getContext().setAuthentication(null);
     }
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/repository/TokenRepository.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/repository/TokenRepository.java
@@ -1,0 +1,15 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.auth.repository;
+
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends CrudRepository<Token, String> {
+
+    Optional<Token> findByAccessToken(String accessToken);
+
+    Optional<Token> findByLoginId(String loginId);
+}

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/TokenService.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/TokenService.java
@@ -1,0 +1,52 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.auth.service;
+
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception.TokenNotFoundException;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.repository.TokenRepository;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+
+    @Transactional
+    public void saveToken(String refreshToken, String accessToken, String loginId) {
+        tokenRepository.save(new Token(refreshToken, accessToken, loginId));
+    }
+
+    @Transactional
+    public void updateAccessToken(String accessToken, String updateAccessToken) {
+        Optional<Token> findToken = tokenRepository.findByAccessToken(accessToken);
+        if (findToken.isPresent()) {
+            Token token = findToken.get();
+            token.setAccessToken(updateAccessToken);
+            tokenRepository.save(token);
+        }else{
+            throw new TokenNotFoundException("엑세스토큰이 존재하지 않습니다.");
+        }
+    }
+
+    @Transactional
+    public void deleteToken(String accessToken) {
+        tokenRepository.findByAccessToken(accessToken)
+                .ifPresent(tokenRepository::delete);
+    }
+
+    @Transactional
+    public Optional<Token> findByAccessToken(String accessToken) {
+        return tokenRepository.findByAccessToken(accessToken);
+    }
+
+    @Transactional
+    public Optional<Token> findByLoginId(String loginId) {
+        return tokenRepository.findByLoginId(loginId);
+    }
+
+}

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/UserService.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/UserService.java
@@ -5,6 +5,7 @@ import isn_t_this_e_not_i.now_waypoint_core.domain.auth.dto.UserResponse;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception.DuplicateLoginIdException;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception.NullFieldException;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.repository.UserRepository;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.User;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.UserRole;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final TokenService tokenService;
 
     //회원 등록
     @Transactional
@@ -61,6 +63,9 @@ public class UserService {
         Optional<User> OptionalUser = userRepository.findByLoginId(loginId);
         if (OptionalUser.isPresent() && bCryptPasswordEncoder.matches(password, OptionalUser.get().getPassword())) {
             userRepository.deleteByLoginId(loginId);
+            String accessToken = tokenService.findByLoginId(loginId).get().getAccessToken();
+            tokenService.deleteToken(accessToken);
+            log.info("회원탈퇴되었습니다.");
         }else{
             throw new UsernameNotFoundException("존재하지 않는 아이디입니다.");
         }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/user/Token.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/user/Token.java
@@ -1,0 +1,24 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.auth.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@AllArgsConstructor
+@Getter
+@RedisHash(value = "userToken", timeToLive =86400)
+public class Token {
+
+    @Id
+    private String refreshToken;
+
+    @Indexed
+    @Setter
+    private String accessToken;
+
+    @Indexed
+    private String loginId;
+}

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/user/User.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/user/User.java
@@ -1,6 +1,8 @@
 package isn_t_this_e_not_i.now_waypoint_core.domain.auth.user;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,15 +23,18 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    //loginEmail
+    @Email(message = "로그인 아이디는 이메일 형식이어야 합니다.")
+    @NotNull
     @Column(unique = true)
     private String loginId;
 
+    @NotNull
     private String password;
 
     private String name;
 
     @Column(unique = true)
+    @NotNull
     private String nickname;
 
     private String profileImageUrl;

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/EmbeddedRedisConfig.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/EmbeddedRedisConfig.java
@@ -1,0 +1,44 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConfiguration;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@Configuration
+@Profile("dev")
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        redisServer = new RedisServer(redisPort);
+        try {
+            redisServer.start();
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Embedded Redis 서버를 시작할 수 없습니다.", e);
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    @Bean
+    public RedisConfig redisConfig() {
+        return new RedisConfig();
+    }
+}

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/RedisConfig.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/now-waypoint-core/src/main/resources/application.properties
+++ b/now-waypoint-core/src/main/resources/application.properties
@@ -4,8 +4,11 @@ spring.profiles.default=dev
 #jwt setting
 spring.jwt.secretKey=asdfkgoirnkdkghgkahndkrnbiejkebnfkjaldoijfjjqiwhekdhnkknkighgkdkfnf
 
-#AccessToken 1??
-spring.jwt.accessToken.Time=3600000
+#AccessToken 10?
+spring.jwt.accessToken.Time=600000
 #refreshToken ??
 spring.jwt.refreshToken.Time=86400000
 
+#Redis setting
+spring.data.redis.host=localhost
+spring.data.redis.port=6379

--- a/now-waypoint-core/src/test/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/RedisConfigTest.java
+++ b/now-waypoint-core/src/test/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/RedisConfigTest.java
@@ -1,0 +1,34 @@
+package isn_t_this_e_not_i.now_waypoint_core.domain.config;
+
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.repository.TokenRepository;
+import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.Token;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class RedisConfigTest {
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Test
+    public void testRedis() {
+        Token token = new Token("refreshToken", "accessToken", "imc@test.com");
+
+        tokenRepository.save(token);
+
+        Optional<Token> accessToken = tokenRepository.findByAccessToken("accessToken");
+
+        if (accessToken.isPresent()) {
+            String loginId = accessToken.get().getLoginId();
+            assertThat(loginId).isEqualTo("imc@test.com");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- jwtToken 처리 방식중 access,refresh Token을 활용한 방식 구현
- 로그인 시 두 개의 토큰 발급(redis저장)
- 인증된 사용자가 url접근 시 access토큰이 없고 refresh토큰이 유효하면 재발급
- 로그아웃 시 두 개의 토큰 제거
- 회원탈퇴 시 두 개의 토큰 제거

## 📝 Describe your changes

## To Reviewers
