### PR TITLE
fix: 닉네임 변경 시 redis에 게시글 조회 오류

### DIFF
--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/post/service/PostRedisService.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/post/service/PostRedisService.java
@@ -49,9 +49,13 @@ public class PostRedisService {
 
     public void update(Post post,String updateNickname){
         PostResponseDTO postResponseDTO = new PostResponseDTO(post);
-        PostRedis postRedis = postRedisRepository.findById(postResponseDTO.getId()).orElseThrow(() -> new IllegalArgumentException("레디스에 일치하는 게시글이 없습니다."));
-        postRedis.setNickname(updateNickname);
-        postRedisRepository.save(postRedis);
+        Optional<PostRedis> optPostRedis = postRedisRepository.findById(postResponseDTO.getId());
+
+        if(optPostRedis.isPresent()){
+            PostRedis postRedis = optPostRedis.get();
+            postRedis.setNickname(updateNickname);
+            postRedisRepository.save(postRedis);
+        }
     }
 
     public void delete(Post post){


### PR DESCRIPTION
## 📌 Summary
- 닉네임 변경 시 redis에 게시글 조회 오류

## 📝 Describe your changes

## To Reviewers
