### PR TITLE
채팅메시지 발신자 업데이트 기능 추가, 채팅방 생성dto 수정

### DIFF
--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/UserService.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/auth/service/UserService.java
@@ -12,6 +12,8 @@ import isn_t_this_e_not_i.now_waypoint_core.domain.auth.exception.auth.Duplicate
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.repository.UserRepository;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.User;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.user.UserRole;
+import isn_t_this_e_not_i.now_waypoint_core.domain.chat.service.ChatMessageService;
+import isn_t_this_e_not_i.now_waypoint_core.domain.chat.service.UserChatRoomService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.post.dto.response.PostResponse;
 import isn_t_this_e_not_i.now_waypoint_core.domain.post.entity.Post;
 import isn_t_this_e_not_i.now_waypoint_core.domain.post.service.FileUploadService;
@@ -47,6 +49,8 @@ public class UserService {
     private final TokenService tokenService;
     private final FileUploadService fileUploadService;
     private final UserFollowService userFollowService;
+    private final ChatMessageService chatMessageService;
+    private final UserChatRoomService userChatRoomService;
 
     //회원 등록
     @Transactional
@@ -209,6 +213,9 @@ public class UserService {
         userFollowService.updateFollowerNickname(nickname, updateNickname);
 
         postService.updatePostByNickname(user, updateNickname);
+
+        userChatRoomService.updateUserNicknameInChatRooms(nickname, updateNickname);
+        chatMessageService.updateUserNicknameInMessages(nickname, updateNickname, loginId);
 
         userRepository.save(user);
         UserResponse.updateNickname userResponse = UserResponse.updateNickname.builder().nickname(nickname).build();

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/dto/MessageType.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/dto/MessageType.java
@@ -10,5 +10,6 @@ public enum MessageType {
     UPDATE,
     NAME_UPDATE,
     ERROR_DUPLICATE,
+    USER_NAME_UPDATE,
     ERROR
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/dto/chatroom/response/UpdateUserNameResponse.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/dto/chatroom/response/UpdateUserNameResponse.java
@@ -1,18 +1,18 @@
 package isn_t_this_e_not_i.now_waypoint_core.domain.chat.dto.chatroom.response;
 
 import isn_t_this_e_not_i.now_waypoint_core.domain.chat.dto.MessageType;
-import lombok.*;
-
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateChatRoomResponse {
+public class UpdateUserNameResponse {
     private MessageType messageType;
     private Long chatRoomId;
-    private String chatRoomName;
-    private String requestUser;
-    private List<ChatRoomUserResponse> userResponses;
+    private String oldNickname;
+    private String newNickname;
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/entity/ChatMessage.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/entity/ChatMessage.java
@@ -1,9 +1,6 @@
 package isn_t_this_e_not_i.now_waypoint_core.domain.chat.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -13,6 +10,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class ChatMessage implements Serializable {
     private Long chatRoomId;
+    @Setter
     private String sender;
     private String content;
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/repository/UserChatRoomRepository.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/chat/repository/UserChatRoomRepository.java
@@ -10,4 +10,6 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
     List<UserChatRoom> findByChatRoomId(Long chatRoomId);
     List<UserChatRoom> findByUserLoginId(String loginId);
     Optional<UserChatRoom> findByUserIdAndChatRoomId(Long userId, Long chatRoomId);
+
+    List<UserChatRoom> findByUserNickname(String nickname);
 }

--- a/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/SecurityConfig.java
+++ b/now-waypoint-core/src/main/java/isn_t_this_e_not_i/now_waypoint_core/domain/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.TokenService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.UserDetailService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.UserFollowService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.auth.service.UserService;
+import isn_t_this_e_not_i.now_waypoint_core.domain.chat.service.ChatMessageService;
+import isn_t_this_e_not_i.now_waypoint_core.domain.chat.service.UserChatRoomService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.post.service.FileUploadService;
 import isn_t_this_e_not_i.now_waypoint_core.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +53,8 @@ public class SecurityConfig {
     private final PostService postService;
     private final FileUploadService fileUploadService;
     private final UserFollowService userFollowService;
+    private final ChatMessageService chatMessageService;
+    private final UserChatRoomService userChatRoomService;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -64,7 +68,7 @@ public class SecurityConfig {
 
     @Bean
     public UserService userService() {
-        return new UserService(postService,userRepository, bCryptPasswordEncoder(), tokenService,fileUploadService, userFollowService);
+        return new UserService(postService, userRepository, bCryptPasswordEncoder(), tokenService,fileUploadService, userFollowService, chatMessageService, userChatRoomService);
     }
 
     @Bean


### PR DESCRIPTION
feat: 유저 닉네임을 변경될때 ChatMessageService에서 채팅메시지의 발신자 업데이트(삭제 후 저장)하는 updateUserNicknameInMessages 메서드 추가, UserChatRoomService에서 chatRoom경로별로 알림정보 보내는 updateUserNicknameInChatRooms메서드 추가 + 채팅방 삭제시 모든 데이터를 삭제시키는 deleteAllMessagesInChatRoom메서드 추가

refactor: 채팅방 생성시 CreateChatRoomResponse 요청유저의 닉네임 변수 추가

## 📌 Summary

## 📝 Describe your changes

## To Reviewers
